### PR TITLE
Update FreeRADIUS parser to work with v3.0

### DIFF
--- a/freeradiusparser.py
+++ b/freeradiusparser.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import codecs
+import six
 
 from pyparsing import (Literal, White, Word, alphanums, CharsNotIn, printables,
                        Forward, Group, OneOrMore, ZeroOrMore,
@@ -113,18 +114,20 @@ class ClientConfParser(BaseParser):
         '''
         :return: The formatted data as it would be written to a file
         '''
-        output = ""
+        output = u""
         output += self.file_header
         for client, attributes in dict_config.items():
-            output += "client %s {\n" % client
+            output += u"client %s {\n" % client
             output += ClientConfParser._format_entry(attributes)
-            output += "}\n\n"
+            output += u"}\n\n"
         return output
 
     @staticmethod
     def _parse_entry(e):
-        if isinstance(e, str):
+        if isinstance(e, six.text_type):
             return e
+        if isinstance(e, six.string_types):  # pragma: no cover
+            return e.decode()
         if len(e) == 0:
             return {}
         return {k: ClientConfParser._parse_entry(v) for k, v in e}
@@ -133,24 +136,26 @@ class ClientConfParser(BaseParser):
     def _format_entry(e, s=False, lvl=4):
         ret = ''
         if len(e) == 0 and s:
-            ret += ' {\n'
+            ret += u' {\n'
         for k, v in e.items():
             if isinstance(v, dict):
                 if s:
-                    ret += ' {0!s} {{\n'.format(k) \
-                           + ClientConfParser._format_entry(v, s=False, lvl=lvl)
+                    ret += u' {0!s} {{\n'.format(k) \
+                           + ClientConfParser._format_entry(v, s=False,
+                                                            lvl=lvl)
                 else:
-                    ret += ' ' * lvl + '{0!s}'.format(k) \
-                           + ClientConfParser._format_entry(v, s=True, lvl=lvl + 4) \
-                           + ' ' * lvl + '}\n'
-            elif isinstance(v, str):
+                    ret += u' ' * lvl + u'{0!s}'.format(k) \
+                           + ClientConfParser._format_entry(v, s=True,
+                                                            lvl=lvl + 4) \
+                           + u' ' * lvl + u'}\n'
+            elif isinstance(v, six.string_types):
                 if s:
-                    ret += ' {\n'
+                    ret += u' {\n'
                     s = False
-                ret += ' ' * lvl + '{0!s} = {1!s}\n'.format(k, v)
+                ret += u' ' * lvl + u'{0!s} = {1!s}\n'.format(k, v)
             else:  # pragma: no cover
                 print('Error formatting freeradius client entry: '
-                      'Unknown type: ' + type(v) + ' ' + e)
+                      'Unknown type: ' + str(type(v)) + ' ' + str(e))
         return ret
 
 

--- a/freeradiusparser.py
+++ b/freeradiusparser.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import codecs
 
-from pyparsing import Literal, White, Word, alphanums, CharsNotIn
-from pyparsing import Forward, Group, Optional, OneOrMore, ZeroOrMore
-from pyparsing import pythonStyleComment, Regex
+from pyparsing import (Literal, White, Word, alphanums, CharsNotIn, printables,
+                       Forward, Group, OneOrMore, ZeroOrMore,
+                       Suppress, pythonStyleComment, Regex)
 
 
 class BaseParser(object):
@@ -13,24 +13,18 @@ class BaseParser(object):
         return the grouped config
         """
         return
-    
+
     def get_dict(self):
-        '''
-        return the client config as a dictionary.
-        '''
-        ret = {}
-        config = self.get()
-        for client in config:
-            client_config = {}
-            for attribute in client[1]:
-                client_config[attribute[0]] = attribute[1]
-            ret[client[0]] = client_config
-        return ret
-    
+        """
+        return the parsed data as a dictionary
+        """
+        return
+
     def dump(self):
-        conf = self.get() or {}
-        for client in conf:
-            print("%s: %s" % (client[0], client[1]))
+        """
+        dump the data to stdout
+        """
+        return
 
     def format(self, dict_config):
         '''
@@ -48,30 +42,25 @@ class BaseParser(object):
 
 
 class ClientConfParser(BaseParser):
-
     key = Word(alphanums + "_")
     client_key = Word(alphanums + "-_/.:")
+    LBRACE, RBRACE, EQUALS, HASH = map(Suppress, '{}=#')
     space = White().suppress()
-    value = CharsNotIn("{}\n# ")
-    comment = "#"
-    assignment = (key
-                  + Optional(space)
-                  + Literal("=").suppress()
-                  + Optional(space)
-                  + value
-                  + Optional(space)
-                  + Optional("#"))
+    value = Word(printables, excludeChars='{}\n# \t')
+    assignment = Group(key + EQUALS + value)
+    intern_section = (LBRACE
+                      + ZeroOrMore(assignment)
+                      + RBRACE)
+    named_section = Group(key + Group(intern_section))
+    sections = Group(key + Group(intern_section | named_section))
     client_block = Forward()
-    client_block << Group((Literal("client").suppress()
-                          + space
-                          + client_key)
-                          + Literal("{").suppress()
-                          + Group(ZeroOrMore(Group(assignment)))
-                          + Literal("}").suppress()
-                          )
-    
+    client_block << Group(Literal("client").suppress()
+                          + client_key
+                          + LBRACE
+                          + Group(ZeroOrMore(assignment ^ sections))
+                          + RBRACE)
     client_file = OneOrMore(client_block).ignore(pythonStyleComment)
-    
+
     file_header = """# File parsed and saved by privacyidea.\n\n"""
     
     def __init__(self,
@@ -101,6 +90,25 @@ class ClientConfParser(BaseParser):
         config = self.client_file.parseString(self.content)
         return config
     
+    def get_dict(self):
+        '''
+        return the client config as a dictionary.
+        '''
+        ret = {}
+        config = self.get()
+        for client in config:
+            client_key = client.pop(0)
+            client_config = {}
+            for attribute in client:
+                client_config.update(ClientConfParser._parse_entry(attribute))
+            ret[client_key] = client_config
+        return ret
+
+    def dump(self):
+        conf = self.get() or {}
+        for client in conf:
+            print("%s: %s" % (client[0], client[1]))
+
     def format(self, dict_config):
         '''
         :return: The formatted data as it would be written to a file
@@ -109,10 +117,41 @@ class ClientConfParser(BaseParser):
         output += self.file_header
         for client, attributes in dict_config.items():
             output += "client %s {\n" % client
-            for k, v in attributes.items():
-                output += "    %s = %s\n" % (k, v)
+            output += ClientConfParser._format_entry(attributes)
             output += "}\n\n"
         return output
+
+    @staticmethod
+    def _parse_entry(e):
+        if isinstance(e, str):
+            return e
+        if len(e) == 0:
+            return {}
+        return {k: ClientConfParser._parse_entry(v) for k, v in e}
+
+    @staticmethod
+    def _format_entry(e, s=False, lvl=4):
+        ret = ''
+        if len(e) == 0 and s:
+            ret += ' {\n'
+        for k, v in e.items():
+            if isinstance(v, dict):
+                if s:
+                    ret += ' {0!s} {{\n'.format(k) \
+                           + ClientConfParser._format_entry(v, s=False, lvl=lvl)
+                else:
+                    ret += ' ' * lvl + '{0!s}'.format(k) \
+                           + ClientConfParser._format_entry(v, s=True, lvl=lvl + 4) \
+                           + ' ' * lvl + '}\n'
+            elif isinstance(v, str):
+                if s:
+                    ret += ' {\n'
+                    s = False
+                ret += ' ' * lvl + '{0!s} = {1!s}\n'.format(k, v)
+            else:  # pragma: no cover
+                print('Error formatting freeradius client entry: '
+                      'Unknown type: ' + type(v) + ' ' + e)
+        return ret
 
 
 class UserConfParser(BaseParser):
@@ -125,7 +164,7 @@ class UserConfParser(BaseParser):
     value = CharsNotIn("{}\n#, ")
     comment = "#"
     # operator = ":="
-    operator = Regex(":=|==|=|\+=|!=|>|>=|<|<=|=~|!~|=\*|!\*")
+    operator = Regex(r":=|==|=|\+=|!=|>|>=|<|<=|=~|!~|=\*|!\*")
     assignment = Group(space
                        + key
                        + space.suppress()
@@ -174,7 +213,13 @@ class UserConfParser(BaseParser):
         """
         config = self.user_file.parseString(self.content)
         return config
-    
+
+    def get_dict(self):
+        pass
+
+    def dump(self):
+        pass
+
     def format(self, config):
         '''
         :return: The formatted data as it would be written to a file

--- a/test_freeradiusparser.py
+++ b/test_freeradiusparser.py
@@ -17,151 +17,78 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
-log = logging.getLogger(__name__)
 import unittest
 import os
+import pytest
+from six.moves.urllib.request import urlopen
 from .freeradiusparser import ClientConfParser, UserConfParser, BaseParser
 
-CLIENT_CONF = """# This is a client.conf for freeradius
+SIMPLE_CLIENTS_CONF_TEST_FILE = 'testdata/clients.conf'
+FILEOUTPUT_SIMPLE_CLIENTS_CONF = """# File parsed and saved by privacyidea.
+
 client localhost {
-        ipaddr          = 127.0.0.1
-        secret          = testing123
-        shortname       = localhost
-        nastype         = other
-}
-
-client private-network-1 {
-        ipaddr          = 192.168.0.0
-        netmask         = 24
-        secret          = testing123-1
-        shortname       = private-network-1
-}
-"""
-
-CLIENT_CONF_ORIG = """#
-# clients.conf - client configuration directives
-#
-#######################################################################
-
-#######################################################################
-#
-#  Definition of a RADIUS client (usually a NAS).
-#
-#  The information given here over rides anything given in the
-#  'clients' file, or in the 'naslist' file.  The configuration here
-#  contains all of the information from those two files, and allows
-#  for more configuration items.
-#
-#  The "shortname" is be used for logging.  The "nastype", "login" and
-#  "password" fields are mainly used for checkrad and are optional.
-#
-
-#
-#  Defines a RADIUS client.  The format is 'client [hostname|ip-address]'
-#
-#  '127.0.0.1' is another name for 'localhost'.  It is enabled by default,
-#  to allow testing of the server after an initial installation.  If you
-#  are not going to be permitting RADIUS queries from localhost, we suggest
-#  that you delete, or comment out, this entry.
-#
-client 127.0.0.1 {
-    #
-    #  The shared secret use to "encrypt" and "sign" packets between
-    #  the NAS and FreeRADIUS.  You MUST change this secret from the
-    #  default, otherwise it's not a secret any more!
-    #
-    #  The secret can be any string, up to 31 characters in length.
-    #
-    secret        = testing123
-
-    #
-    #  The short name is used as an alias for the fully qualified
-    #  domain name, or the IP address.
-    #
-    shortname    = localhost
-
-    #
-    # the following three fields are optional, but may be used by
-    # checkrad.pl for simultaneous use checks
-    #
-
-    #
-    # The nastype tells 'checkrad.pl' which NAS-specific method to
-    #  use to query the NAS for simultaneous use.
-    #
-    #  Permitted NAS types are:
-    #
-    #    cisco
-    #    computone
-    #    livingston
-    #    max40xx
-    #    multitech
-    #    netserver
-    #    pathras
-    #    patton
-    #    portslave
-    #    tc
-    #    usrhiper
-    #    other        # for all other types
-
-    #
-    nastype     = other    # localhost isn't usually a NAS...
-
-    #
-    #  The following two configurations are for future use.
-    #  The 'naspasswd' file is currently used to store the NAS
-    #  login name and password, which is used by checkrad.pl
-    #  when querying the NAS for simultaneous use.
-    #
-#    login       = !root
-#    password    = someadminpas
-}
-
-#client some.host.org {
-#    secret        = testing123
-#    shortname    = localhost
-#}
-
-#
-#  You can now specify one secret for a network of clients.
-#  When a client request comes in, the BEST match is chosen.
-#  i.e. The entry from the smallest possible network.
-#
-#client 192.168.0.0/24 {
-#    secret        = testing123-1
-#    shortname    = private-network-1
-#}
-#
-#client 192.168.0.0/16 {
-#    secret        = testing123-2
-#    shortname    = private-network-2
-#}
-
-
-#client 10.10.10.10 {
-#    # secret and password are mapped through the "secrets" file.
-#    secret      = testing123
-#    shortname   = liv1
-#       # the following three fields are optional, but may be used by
-#       # checkrad.pl for simultaneous usage checks
-#    nastype     = livingston
-#    login       = !root
-#    password    = someadminpas
-#}
-
-
-"""
-
-FILEOUTPUT_ORIG = """# File parsed and saved by privacyidea.
-
-client 127.0.0.1 {
+    ipaddr = 127.0.0.1
     secret = testing123
     shortname = localhost
     nastype = other
 }
 
+client private-network-1 {
+    ipaddr = 192.168.0.0
+    netmask = 24
+    secret = testing123-1
+    shortname = private-network-1
+}
+
 """
+
+CLIENTS_CONF_TEST_FILE = 'testdata/test_clients.conf'
+
+CLIENTS_CONF_RAD30_FILE = 'testdata/rad30_clients.conf'
+FILEOUTPUT_RAD30 = """# File parsed and saved by privacyidea.
+
+client localhost {
+    ipaddr = 127.0.0.1
+    proto = *
+    secret = testing123
+    require_message_authenticator = no
+    nas_type = other
+    limit {
+        max_connections = 16
+        lifetime = 0
+        idle_timeout = 30
+    }
+}
+
+client localhost_ipv6 {
+    ipv6addr = ::1
+    secret = testing123
+}
+
+"""
+
+CLIENTS_CONF_CURRENT_URL = 'https://raw.githubusercontent.com/FreeRADIUS/freeradius-server/master/raddb/clients.conf'
+FILEOUTPUT_CURRENT = """# File parsed and saved by privacyidea.
+
+client localhost {
+    ipaddr = 127.0.0.1
+    proto = *
+    secret = testing123
+    require_message_authenticator = no
+    limit {
+        max_connections = 16
+        lifetime = 0
+        idle_timeout = 30
+    }
+}
+
+client localhost_ipv6 {
+    ipv6addr = ::1
+    secret = testing123
+}
+
+"""
+
 
 USER_CONF_A = """
 DEFAULT Auth-Type := perl
@@ -185,211 +112,8 @@ DEFAULT    Hint == "SLIP"
     Something = Else
 """
 
-USER_CONF_1 = """
-#
-#    Please read the documentation file ../doc/processing_users_file,
-#    or 'man 5 users' (after installing the server) for more information.
-#
-#    This file contains authentication security and configuration
-#    information for each user.  Accounting requests are NOT processed
-#    through this file.  Instead, see 'acct_users', in this directory.
-#
-#    The first field is the user's name and can be up to
-#    253 characters in length.  This is followed (on the same line) with
-#    the list of authentication requirements for that user.  This can
-#    include password, comm server name, comm server port number, protocol
-#    type (perhaps set by the "hints" file), and huntgroup name (set by
-#    the "huntgroups" file).
-#
-#    If you are not sure why a particular reply is being sent by the
-#    server, then run the server in debugging mode (radiusd -X), and
-#    you will see which entries in this file are matched.
-#
-#    When an authentication request is received from the comm server,
-#    these values are tested. Only the first match is used unless the
-#    "Fall-Through" variable is set to "Yes".
-#
-#    A special user named "DEFAULT" matches on all usernames.
-#    You can have several DEFAULT entries. All entries are processed
-#    in the order they appear in this file. The first entry that
-#    matches the login-request will stop processing unless you use
-#    the Fall-Through variable.
-#
-#    If you use the database support to turn this file into a .db or .dbm
-#    file, the DEFAULT entries _have_ to be at the end of this file and
-#    you can't have multiple entries for one username.
-#
-#    Indented (with the tab character) lines following the first
-#    line indicate the configuration values to be passed back to
-#    the comm server to allow the initiation of a user session.
-#    This can include things like the PPP configuration values
-#    or the host to log the user onto.
-#
-#    You can include another `users' file with `$INCLUDE users.other'
-#
-
-#
-#    For a list of RADIUS attributes, and links to their definitions,
-#    see:
-#
-#    http://www.freeradius.org/rfc/attributes.html
-#
-
-#
-# Deny access for a specific user.  Note that this entry MUST
-# be before any other 'Auth-Type' attribute which results in the user
-# being authenticated.
-#
-# Note that there is NO 'Fall-Through' attribute, so the user will not
-# be given any additional resources.
-#
-#lameuser    Auth-Type := Reject
-#        Reply-Message = "Your account has been disabled."
-
-#
-# Deny access for a group of users.
-#
-# Note that there is NO 'Fall-Through' attribute, so the user will not
-# be given any additional resources.
-#
-#DEFAULT    Group == "disabled", Auth-Type := Reject
-#        Reply-Message = "Your account has been disabled."
-#
-
-#
-# This is a complete entry for "steve". Note that there is no Fall-Through
-# entry so that no DEFAULT entry will be used, and the user will NOT
-# get any attributes in addition to the ones listed here.
-#
-#steve    Cleartext-Password := "testing"
-#    Service-Type = Framed-User,
-#    Framed-Protocol = PPP,
-#    Framed-IP-Address = 172.16.3.33,
-#    Framed-IP-Netmask = 255.255.255.0,
-#    Framed-Routing = Broadcast-Listen,
-#    Framed-Filter-Id = "std.ppp",
-#    Framed-MTU = 1500,
-#    Framed-Compression = Van-Jacobsen-TCP-IP
-
-#
-# This is an entry for a user with a space in their name.
-# Note the double quotes surrounding the name.
-#
-#"John Doe"    Cleartext-Password := "hello"
-#        Reply-Message = "Hello, %{User-Name}"
-
-#
-# Dial user back and telnet to the default host for that port
-#
-#Deg    Cleartext-Password := "ge55ged"
-#    Service-Type = Callback-Login-User,
-#    Login-IP-Host = 0.0.0.0,
-#    Callback-Number = "9,5551212",
-#    Login-Service = Telnet,
-#    Login-TCP-Port = Telnet
-
-#
-# Another complete entry. After the user "dialbk" has logged in, the
-# connection will be broken and the user will be dialed back after which
-# he will get a connection to the host "timeshare1".
-#
-#dialbk    Cleartext-Password := "callme"
-#    Service-Type = Callback-Login-User,
-#    Login-IP-Host = timeshare1,
-#    Login-Service = PortMaster,
-#    Callback-Number = "9,1-800-555-1212"
-
-#
-# user "swilson" will only get a static IP number if he logs in with
-# a framed protocol on a terminal server in Alphen (see the huntgroups file).
-#
-# Note that by setting "Fall-Through", other attributes will be added from
-# the following DEFAULT entries
-#
-#swilson    Service-Type == Framed-User, Huntgroup-Name == "alphen"
-#        Framed-IP-Address = 192.168.1.65,
-#        Fall-Through = Yes
-
-#
-# If the user logs in as 'username.shell', then authenticate them
-# using the default method, give them shell access, and stop processing
-# the rest of the file.
-#
-#DEFAULT    Suffix == ".shell"
-#        Service-Type = Login-User,
-#        Login-Service = Telnet,
-#        Login-IP-Host = your.shell.machine
-
-
-#
-# The rest of this file contains the several DEFAULT entries.
-# DEFAULT entries match with all login names.
-# Note that DEFAULT entries can also Fall-Through (see first entry).
-# A name-value pair from a DEFAULT entry will _NEVER_ override
-# an already existing name-value pair.
-#
-
-#
-# Set up different IP address pools for the terminal servers.
-# Note that the "+" behind the IP address means that this is the "base"
-# IP address. The Port-Id (S0, S1 etc) will be added to it.
-#
-#DEFAULT    Service-Type == Framed-User, Huntgroup-Name == "alphen"
-#        Framed-IP-Address = 192.168.1.32+,
-#        Fall-Through = Yes
-
-#DEFAULT    Service-Type == Framed-User, Huntgroup-Name == "delft"
-#        Framed-IP-Address = 192.168.2.32+,
-#        Fall-Through = Yes
-
-#
-# Sample defaults for all framed connections.
-#
-#DEFAULT    Service-Type == Framed-User
-#    Framed-IP-Address = 255.255.255.254,
-#    Framed-MTU = 576,
-#    Service-Type = Framed-User,
-#    Fall-Through = Yes
-
-#
-# Default for PPP: dynamic IP address, PPP mode, VJ-compression.
-# NOTE: we do not use Hint = "PPP", since PPP might also be auto-detected
-#    by the terminal server in which case there may not be a "P" suffix.
-#    The terminal server sends "Framed-Protocol = PPP" for auto PPP.
-#
-DEFAULT    Framed-Protocol == PPP
-    Framed-Protocol = PPP,
-    Framed-Compression = Van-Jacobson-TCP-IP
-
-#
-# Default for CSLIP: dynamic IP address, SLIP mode, VJ-compression.
-#
-DEFAULT    Hint == "CSLIP"
-    Framed-Protocol = SLIP,
-    Framed-Compression = Van-Jacobson-TCP-IP
-
-#
-# Default for SLIP: dynamic IP address, SLIP mode.
-#
-DEFAULT    Hint == "SLIP"
-    Framed-Protocol = SLIP
-
-#
-# Last default: rlogin to our main server.
-#
-#DEFAULT
-#    Service-Type = Login-User,
-#    Login-Service = Rlogin,
-#    Login-IP-Host = shellbox.ispdomain.com
-
-# #
-# # Last default: shell on the local terminal server.
-# #
-# DEFAULT
-#     Service-Type = Administrative-User
-
-# On no match, the user is denied access.
-"""
+USER_CONF_RAD30_FILE = 'testdata/users_rad30'
+USER_CONF_CURRENT_URL = 'https://raw.githubusercontent.com/FreeRADIUS/freeradius-server/v3.0.x/raddb/mods-config/files/authorize'
 
 FILEOUTPUT_USER_ORIG = """# File parsed and saved by privacyidea.
 
@@ -406,21 +130,27 @@ DEFAULT Hint == "SLIP"
 
 """
 
+SIMPLE_USER_CONF_FILE = 'testdata/users'
+
 
 class TestBaseParser(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        self.capsys = capsys
 
     def test_base_parser(self):
         bp = BaseParser()
         r = bp.get()
         self.assertEqual(r, None)
-
         bp.dump()
-
+        captured = self.capsys.readouterr()
+        assert captured.out == ''
         r = bp.format({})
         self.assertEqual(r, None)
 
         # do nothing
         bp.save({}, "test.out")
+        assert not os.path.exists('test.out')
 
 
 class TestFreeRADIUSParser(unittest.TestCase):
@@ -429,9 +159,8 @@ class TestFreeRADIUSParser(unittest.TestCase):
         pass
     
     def test_clients_conf_simple(self):
-        CP = ClientConfParser(content=CLIENT_CONF)
+        CP = ClientConfParser(infile='testdata/clients.conf')
         config = CP.get_dict()
-        print(config)
         self.assertTrue("localhost" in config)
         self.assertTrue("private-network-1" in config)
         self.assertEqual(config.get("private-network-1").get("secret"),
@@ -439,36 +168,53 @@ class TestFreeRADIUSParser(unittest.TestCase):
         self.assertEqual(config.get("private-network-1").get("shortname"),
                          "private-network-1")
         
-    def test_clients_conf_original(self):
-        CP = ClientConfParser(content=CLIENT_CONF_ORIG)
+    def test_clients_conf_current_from_github(self):
+        # load the raw clients.conf from the freeRADIUS github page
+        # and compare it with a local version. This way we know if something
+        # changed in the original
+        try:
+            response = urlopen(CLIENTS_CONF_CURRENT_URL)
+        except RuntimeError as e:
+            print(e)
+            pytest.xfail('Could not get data from net!')
+
+        content = response.read().decode()
+        CP = ClientConfParser(content=content)
         config = CP.get_dict()
-        print(config)
-        # {'127.0.0.1': {'secret': 'testing123', 'shortname': 'localhost',
-        # 'nastype': 'other    '}}
-        self.assertTrue("localhost" not in config)
-        self.assertTrue("127.0.0.1" in config)
-        self.assertEqual(config.get("127.0.0.1").get("secret"),
+        assert "localhost" in config
+        assert "localhost_ipv6" in config
+        assert "127.0.0.1" not in config
+        self.assertEqual(config.get("localhost").get("secret"),
                          "testing123")
-        self.assertEqual(config.get("127.0.0.1").get("nastype"),
-                         "other")
+        self.assertEqual(config.get("localhost").get("ipaddr"),
+                         "127.0.0.1")
         
         output = CP.format(config)
-        print(output)
-        self.assertEqual(output, FILEOUTPUT_ORIG)
+        self.assertEqual(output, FILEOUTPUT_CURRENT)
         
+    def test_clients_conf_original_freerad30(self):
+        cp = ClientConfParser(infile=CLIENTS_CONF_RAD30_FILE)
+        config = cp.get_dict()
+        self.assertIn('localhost', config, config)
+        self.assertIn('localhost_ipv6', config, config)
+        assert cp.format(config) == FILEOUTPUT_RAD30
+
+    def test_clients_conf_with_sections(self):
+        cp = ClientConfParser(infile=CLIENTS_CONF_TEST_FILE)
+        config = cp.get_dict()
+        fmt = cp.format(config)
+        # TODO: check sections
+
     def test_save_file(self):
         tmpfile = "./tmp-output"
-        CP = ClientConfParser(content=CLIENT_CONF_ORIG)
+        CP = ClientConfParser(infile=SIMPLE_CLIENTS_CONF_TEST_FILE)
         config = CP.get_dict()
-        print(config)
         CP.save(config, tmpfile)
         f = open(tmpfile, "r")
         output = f.read()
         f.close()
         os.unlink(tmpfile)
-        print(output)
-
-        self.assertEqual(output, FILEOUTPUT_ORIG)
+        self.assertEqual(output, FILEOUTPUT_SIMPLE_CLIENTS_CONF)
         
 
 class TestFreeRADIUSUsers(unittest.TestCase):
@@ -479,7 +225,6 @@ class TestFreeRADIUSUsers(unittest.TestCase):
     def test_users_basic(self):
         UP = UserConfParser(content=USER_CONF_A)
         config = UP.get()
-        print(config)
         self.assertEqual(config[0][0], "DEFAULT")
         self.assertEqual(config[0][1], "Auth-Type")
         self.assertEqual(config[0][2], ":=")
@@ -488,7 +233,6 @@ class TestFreeRADIUSUsers(unittest.TestCase):
     def test_users_password(self):
         UP = UserConfParser(content=USER_CONF_B)
         config = UP.get()
-        print(config)
         self.assertEqual(config[0][0], "administrator")
         self.assertEqual(config[0][1], "Cleartext-Password")
         self.assertEqual(config[0][2], ":=")
@@ -497,7 +241,6 @@ class TestFreeRADIUSUsers(unittest.TestCase):
     def test_operators(self):
         UP = UserConfParser(content=USER_CONF_C)
         config = UP.get()
-        print(config)
         self.assertEqual(config[0][0], "user")
         self.assertEqual(config[0][1], "somekey")
         self.assertEqual(config[0][2], "==")
@@ -506,7 +249,6 @@ class TestFreeRADIUSUsers(unittest.TestCase):
     def test_reply_items(self):
         UP = UserConfParser(content=USER_CONF_D)
         config = UP.get()
-        print(config)
         # [['DEFAULT', 'Hint', '==', '"SLIP"',
         #  [['Framed-Protocol', '=', 'SLIP']]]
         # ]
@@ -522,7 +264,6 @@ class TestFreeRADIUSUsers(unittest.TestCase):
     def test_reply_items2(self):
         UP = UserConfParser(content=USER_CONF_E)
         config = UP.get()
-        print(config)
         # [['DEFAULT', 'Hint', '==', '"SLIP"',
         #  [['Framed-Protocol', '=', 'SLIP']]]
         # ]
@@ -539,33 +280,26 @@ class TestFreeRADIUSUsers(unittest.TestCase):
         self.assertEqual(config[0][4][1][2], 'Else')
     
     def test_get_complete(self):
-        UP = UserConfParser(content=USER_CONF_1)
+        UP = UserConfParser(infile=USER_CONF_RAD30_FILE)
         config = UP.get()
-        print(len(config))
         self.assertEqual(len(config), 3)
-        print(config[0])
-        print(config[1])
-        print(config[2])
         self.assertEqual(len(config[0][4]), 2)
         self.assertEqual(len(config[1][4]), 2)
         self.assertEqual(len(config[2][4]), 1)
         
     def test_save_file(self):
         tmpfile = "./tmp-output"
-        UP = UserConfParser(content=USER_CONF_1)
+        UP = UserConfParser(infile=USER_CONF_RAD30_FILE)
         config = UP.get()
-        print(config)
         UP.save(config, tmpfile)
         f = open(tmpfile, "r")
         output = f.read()
         f.close()
         os.unlink(tmpfile)
-        print(output)
-
         self.assertEqual(output, FILEOUTPUT_USER_ORIG)
 
     def test_read_user_from_file(self):
-        UP = UserConfParser(infile="./testdata/users")
+        UP = UserConfParser(infile=SIMPLE_USER_CONF_FILE)
         config = UP.get()
         user1 = config[0]
         user2 = config[1]
@@ -575,7 +309,14 @@ class TestFreeRADIUSUsers(unittest.TestCase):
         # Just dump it
         UP.dump()
 
-    def test_read_clients_from_file(self):
-        CP = ClientConfParser(infile="./testdata/clients.conf")
-        config = CP.get()
-        self.assertEqual(len(config), 2)
+    def test_current_user_config_from_github(self):
+        try:
+            response = urlopen(USER_CONF_CURRENT_URL)
+        except RuntimeError as e:
+            print(e)
+            pytest.xfail('Could not get data from net!')
+
+        content = response.read().decode()
+        up = UserConfParser(content=content)
+        output = up.format(up.get())
+        assert output == FILEOUTPUT_USER_ORIG

--- a/testdata/rad30_clients.conf
+++ b/testdata/rad30_clients.conf
@@ -1,0 +1,268 @@
+# -*- text -*-
+##
+## clients.conf -- client configuration directives
+##
+##	$Id: 76b300d3c55f1c5c052289b76bf28ac3a370bbb2 $
+
+#######################################################################
+#
+#  Define RADIUS clients (usually a NAS, Access Point, etc.).
+
+#
+#  Defines a RADIUS client.
+#
+#  '127.0.0.1' is another name for 'localhost'.  It is enabled by default,
+#  to allow testing of the server after an initial installation.  If you
+#  are not going to be permitting RADIUS queries from localhost, we suggest
+#  that you delete, or comment out, this entry.
+#
+#
+
+#
+#  Each client has a "short name" that is used to distinguish it from
+#  other clients.
+#
+#  In version 1.x, the string after the word "client" was the IP
+#  address of the client.  In 2.0, the IP address is configured via
+#  the "ipaddr" or "ipv6addr" fields.  For compatibility, the 1.x
+#  format is still accepted.
+#
+client localhost {
+	#  Only *one* of ipaddr, ipv4addr, ipv6addr may be specified for
+	#  a client.
+	#
+	#  ipaddr will accept IPv4 or IPv6 addresses with optional CIDR
+	#  notation '/<mask>' to specify ranges.
+	#
+	#  ipaddr will accept domain names e.g. example.org resolving
+	#  them via DNS.
+	#
+	#  If both A and AAAA records are found, A records will be
+	#  used in preference to AAAA.
+	ipaddr = 127.0.0.1
+
+	#  Same as ipaddr but allows v4 addresses only. Requires A
+	#  record for domain names.
+#	ipv4addr = *	# any.  127.0.0.1 == localhost
+
+	#  Same as ipaddr but allows v6 addresses only. Requires AAAA
+	#  record for domain names.
+#	ipv6addr = ::	# any.  ::1 == localhost
+
+	#
+	#  A note on DNS:  We STRONGLY recommend using IP addresses
+	#  rather than host names.  Using host names means that the
+	#  server will do DNS lookups when it starts, making it
+	#  dependent on DNS.  i.e. If anything goes wrong with DNS,
+	#  the server won't start!
+	#
+	#  The server also looks up the IP address from DNS once, and
+	#  only once, when it starts.  If the DNS record is later
+	#  updated, the server WILL NOT see that update.
+	#
+
+	#
+	#  The transport protocol.
+	#
+	#  If unspecified, defaults to "udp", which is the traditional
+	#  RADIUS transport.  It may also be "tcp", in which case the
+	#  server will accept connections from this client ONLY over TCP.
+	#
+	proto = *
+
+	#
+	#  The shared secret use to "encrypt" and "sign" packets between
+	#  the NAS and FreeRADIUS.  You MUST change this secret from the
+	#  default, otherwise it's not a secret any more!
+	#
+	#  The secret can be any string, up to 8k characters in length.
+	#
+	#  Control codes can be entered vi octal encoding,
+	#	e.g. "\101\102" == "AB"
+	#  Quotation marks can be entered by escaping them,
+	#	e.g. "foo\"bar"
+	#
+	#  A note on security:  The security of the RADIUS protocol
+	#  depends COMPLETELY on this secret!  We recommend using a
+	#  shared secret that is composed of:
+	#
+	#	upper case letters
+	#	lower case letters
+	#	numbers
+	#
+	#  And is at LEAST 8 characters long, preferably 16 characters in
+	#  length.  The secret MUST be random, and should not be words,
+	#  phrase, or anything else that is recognisable.
+	#
+	#  The default secret below is only for testing, and should
+	#  not be used in any real environment.
+	#
+	secret = testing123
+
+	#
+	#  Old-style clients do not send a Message-Authenticator
+	#  in an Access-Request.  RFC 5080 suggests that all clients
+	#  SHOULD include it in an Access-Request.  The configuration
+	#  item below allows the server to require it.  If a client
+	#  is required to include a Message-Authenticator and it does
+	#  not, then the packet will be silently discarded.
+	#
+	#  allowed values: yes, no
+	require_message_authenticator = no
+
+	#
+	#  The short name is used as an alias for the fully qualified
+	#  domain name, or the IP address.
+	#
+	#  It is accepted for compatibility with 1.x, but it is no
+	#  longer necessary in >= 2.0
+	#
+#	shortname = localhost
+
+	#
+	# the following three fields are optional, but may be used by
+	# checkrad.pl for simultaneous use checks
+	#
+
+	#
+	# The nas_type tells 'checkrad.pl' which NAS-specific method to
+	#  use to query the NAS for simultaneous use.
+	#
+	#  Permitted NAS types are:
+	#
+	#	cisco
+	#	computone
+	#	livingston
+	#	juniper
+	#	max40xx
+	#	multitech
+	#	netserver
+	#	pathras
+	#	patton
+	#	portslave
+	#	tc
+	#	usrhiper
+	#	other		# for all other types
+
+	#
+	nas_type	 = other	# localhost isn't usually a NAS...
+
+	#
+	#  The following two configurations are for future use.
+	#  The 'naspasswd' file is currently used to store the NAS
+	#  login name and password, which is used by checkrad.pl
+	#  when querying the NAS for simultaneous use.
+	#
+#	login	   = !root
+#	password	= someadminpas
+
+	#
+	#  As of 2.0, clients can also be tied to a virtual server.
+	#  This is done by setting the "virtual_server" configuration
+	#  item, as in the example below.
+	#
+#	virtual_server = home1
+
+	#
+	#  A pointer to the "home_server_pool" OR a "home_server"
+	#  section that contains the CoA configuration for this
+	#  client.  For an example of a coa home server or pool,
+	#  see raddb/sites-available/originate-coa
+#	coa_server = coa
+
+	#
+	#  Response window for proxied packets.  If non-zero,
+	#  then the lower of (home, client) response_window
+	#  will be used.
+	#
+	#  i.e. it can be used to lower the response_window
+	#  packets from one client to a home server.  It cannot
+	#  be used to raise the response_window.
+	#
+#	response_window = 10.0
+
+	#
+	#  Connection limiting for clients using "proto = tcp".
+	#
+	#  This section is ignored for clients sending UDP traffic
+	#
+	limit {
+		#
+		#  Limit the number of simultaneous TCP connections from a client
+		#
+		#  The default is 16.
+		#  Setting this to 0 means "no limit"
+		max_connections = 16
+
+		#  The per-socket "max_requests" option does not exist.
+
+		#
+		#  The lifetime, in seconds, of a TCP connection.  After
+		#  this lifetime, the connection will be closed.
+		#
+		#  Setting this to 0 means "forever".
+		lifetime = 0
+
+		#
+		#  The idle timeout, in seconds, of a TCP connection.
+		#  If no packets have been received over the connection for
+		#  this time, the connection will be closed.
+		#
+		#  Setting this to 0 means "no timeout".
+		#
+		#  We STRONGLY RECOMMEND that you set an idle timeout.
+		#
+		idle_timeout = 30
+	}
+}
+
+# IPv6 Client
+client localhost_ipv6 {
+	ipv6addr	= ::1
+	secret		= testing123
+}
+
+# All IPv6 Site-local clients
+#client sitelocal_ipv6 {
+#	ipv6addr	= fe80::/16
+#	secret		= testing123
+#}
+
+#client example.org {
+#	ipaddr		= radius.example.org
+#	secret		= testing123
+#}
+
+#
+#  You can now specify one secret for a network of clients.
+#  When a client request comes in, the BEST match is chosen.
+#  i.e. The entry from the smallest possible network.
+#
+#client private-network-1 {
+#	ipaddr		= 192.0.2.0/24
+#	secret		= testing123-1
+#}
+
+#client private-network-2 {
+#	ipaddr		= 198.51.100.0/24
+#	secret		= testing123-2
+#}
+
+#######################################################################
+#
+#  Per-socket client lists.  The configuration entries are exactly
+#  the same as above, but they are nested inside of a section.
+#
+#  You can have as many per-socket client lists as you have "listen"
+#  sections, or you can re-use a list among multiple "listen" sections.
+#
+#  Un-comment this section, and edit a "listen" section to add:
+#  "clients = per_socket_clients".  That IP address/port combination
+#  will then accept ONLY the clients listed in this section.
+#
+#clients per_socket_clients {
+#	client socket_client {
+#		ipaddr = 192.0.2.4
+#		secret = testing123
+#	}
+#}

--- a/testdata/test_clients.conf
+++ b/testdata/test_clients.conf
@@ -1,0 +1,46 @@
+# client with unnamed section
+client 127.0.0.1 {
+    secret = testing123
+    shortname = localhost
+    nastype = other
+    limit {
+        lifetime = 0
+    }
+}
+# client with empty section
+client 127.0.0.2 {
+    secret = testing123
+    shortname = localhost
+    nastype = other
+    limit {
+    }
+}
+
+# client with a named section
+client 127.0.0.3 {
+    secret = testing123
+    shortname = localhost
+    nastype = other
+    limit foo {
+        lifetime = 0
+    }
+}
+
+# client with empty named section
+client 127.0.0.4 {
+    secret = testing123
+    shortname = localhost
+    nastype = other
+    limit foo {
+    }
+} # comment after closing client brace
+
+# client block with some comments
+client foo { # comment after opening client brace
+    secret = testing123
+    shortname = bar  # comment after assignment
+    limit baz { # comment after opening brace
+        lifetime = 1
+    }# comment after closing brace
+    nastype = other
+}

--- a/testdata/users_rad30
+++ b/testdata/users_rad30
@@ -1,0 +1,220 @@
+#
+# 	Configuration file for the rlm_files module.
+# 	Please see rlm_files(5) manpage for more information.
+#
+# 	This file contains authentication security and configuration
+#	information for each user.  Accounting requests are NOT processed
+#	through this file.  Instead, see 'accounting', in this directory.
+#
+#	The first field is the user's name and can be up to
+#	253 characters in length.  This is followed (on the same line) with
+#	the list of authentication requirements for that user.  This can
+#	include password, comm server name, comm server port number, protocol
+#	type (perhaps set by the "hints" file), and huntgroup name (set by
+#	the "huntgroups" file).
+#
+#	If you are not sure why a particular reply is being sent by the
+#	server, then run the server in debugging mode (radiusd -X), and
+#	you will see which entries in this file are matched.
+#
+#	When an authentication request is received from the comm server,
+#	these values are tested. Only the first match is used unless the
+#	"Fall-Through" variable is set to "Yes".
+#
+#	A special user named "DEFAULT" matches on all usernames.
+#	You can have several DEFAULT entries. All entries are processed
+#	in the order they appear in this file. The first entry that
+#	matches the login-request will stop processing unless you use
+#	the Fall-Through variable.
+#
+#	Indented (with the tab character) lines following the first
+#	line indicate the configuration values to be passed back to
+#	the comm server to allow the initiation of a user session.
+#	This can include things like the PPP configuration values
+#	or the host to log the user onto.
+#
+#	You can include another `users' file with `$INCLUDE users.other'
+
+#
+#	For a list of RADIUS attributes, and links to their definitions,
+#	see: http://www.freeradius.org/rfc/attributes.html
+#
+#	Entries below this point are examples included in the server for
+#	educational purposes. They may be deleted from the deployed
+#	configuration without impacting the operation of the server.
+#
+
+#
+# Deny access for a specific user.  Note that this entry MUST
+# be before any other 'Auth-Type' attribute which results in the user
+# being authenticated.
+#
+# Note that there is NO 'Fall-Through' attribute, so the user will not
+# be given any additional resources.
+#
+#lameuser	Auth-Type := Reject
+#		Reply-Message = "Your account has been disabled."
+
+#
+# Deny access for a group of users.
+#
+# Note that there is NO 'Fall-Through' attribute, so the user will not
+# be given any additional resources.
+#
+#DEFAULT	Group == "disabled", Auth-Type := Reject
+#		Reply-Message = "Your account has been disabled."
+#
+
+#
+# This is a complete entry for "steve". Note that there is no Fall-Through
+# entry so that no DEFAULT entry will be used, and the user will NOT
+# get any attributes in addition to the ones listed here.
+#
+#steve	Cleartext-Password := "testing"
+#	Service-Type = Framed-User,
+#	Framed-Protocol = PPP,
+#	Framed-IP-Address = 172.16.3.33,
+#	Framed-IP-Netmask = 255.255.255.0,
+#	Framed-Routing = Broadcast-Listen,
+#	Framed-Filter-Id = "std.ppp",
+#	Framed-MTU = 1500,
+#	Framed-Compression = Van-Jacobsen-TCP-IP
+
+#
+# The canonical testing user which is in most of the
+# examples.
+#
+#bob	Cleartext-Password := "hello"
+#	Reply-Message := "Hello, %{User-Name}"
+#
+
+#
+# This is an entry for a user with a space in their name.
+# Note the double quotes surrounding the name.  If you have
+# users with spaces in their names, you must also change
+# the "filter_username" policy to allow spaces.
+#
+# See raddb/policy.d/filter, filter_username {} section.
+#
+#"John Doe"	Cleartext-Password := "hello"
+#		Reply-Message = "Hello, %{User-Name}"
+
+#
+# Dial user back and telnet to the default host for that port
+#
+#Deg	Cleartext-Password := "ge55ged"
+#	Service-Type = Callback-Login-User,
+#	Login-IP-Host = 0.0.0.0,
+#	Callback-Number = "9,5551212",
+#	Login-Service = Telnet,
+#	Login-TCP-Port = Telnet
+
+#
+# Another complete entry. After the user "dialbk" has logged in, the
+# connection will be broken and the user will be dialed back after which
+# he will get a connection to the host "timeshare1".
+#
+#dialbk	Cleartext-Password := "callme"
+#	Service-Type = Callback-Login-User,
+#	Login-IP-Host = timeshare1,
+#	Login-Service = PortMaster,
+#	Callback-Number = "9,1-800-555-1212"
+
+#
+# user "swilson" will only get a static IP number if he logs in with
+# a framed protocol on a terminal server in Alphen (see the huntgroups file).
+#
+# Note that by setting "Fall-Through", other attributes will be added from
+# the following DEFAULT entries
+#
+#swilson	Service-Type == Framed-User, Huntgroup-Name == "alphen"
+#		Framed-IP-Address = 192.0.2.65,
+#		Fall-Through = Yes
+
+#
+# If the user logs in as 'username.shell', then authenticate them
+# using the default method, give them shell access, and stop processing
+# the rest of the file.
+#
+#DEFAULT	Suffix == ".shell"
+#		Service-Type = Login-User,
+#		Login-Service = Telnet,
+#		Login-IP-Host = your.shell.machine
+
+
+#
+# The rest of this file contains the several DEFAULT entries.
+# DEFAULT entries match with all login names.
+# Note that DEFAULT entries can also Fall-Through (see first entry).
+# A name-value pair from a DEFAULT entry will _NEVER_ override
+# an already existing name-value pair.
+#
+
+#
+# Set up different IP address pools for the terminal servers.
+# Note that the "+" behind the IP address means that this is the "base"
+# IP address. The Port-Id (S0, S1 etc) will be added to it.
+#
+#DEFAULT	Service-Type == Framed-User, Huntgroup-Name == "alphen"
+#		Framed-IP-Address = 192.0.2.32+,
+#		Fall-Through = Yes
+
+#DEFAULT	Service-Type == Framed-User, Huntgroup-Name == "delft"
+#		Framed-IP-Address = 198.51.100.32+,
+#		Fall-Through = Yes
+
+#
+# Sample defaults for all framed connections.
+#
+#DEFAULT	Service-Type == Framed-User
+#	Framed-IP-Address = 255.255.255.254,
+#	Framed-MTU = 576,
+#	Service-Type = Framed-User,
+#	Fall-Through = Yes
+
+#
+# Default for PPP: dynamic IP address, PPP mode, VJ-compression.
+# NOTE: we do not use Hint = "PPP", since PPP might also be auto-detected
+#	by the terminal server in which case there may not be a "P" suffix.
+#	The terminal server sends "Framed-Protocol = PPP" for auto PPP.
+#
+DEFAULT	Framed-Protocol == PPP
+	Framed-Protocol = PPP,
+	Framed-Compression = Van-Jacobson-TCP-IP
+
+#
+# Default for CSLIP: dynamic IP address, SLIP mode, VJ-compression.
+#
+DEFAULT	Hint == "CSLIP"
+	Framed-Protocol = SLIP,
+	Framed-Compression = Van-Jacobson-TCP-IP
+
+#
+# Default for SLIP: dynamic IP address, SLIP mode.
+#
+DEFAULT	Hint == "SLIP"
+	Framed-Protocol = SLIP
+
+#
+# Last default: rlogin to our main server.
+#
+#DEFAULT
+#	Service-Type = Login-User,
+#	Login-Service = Rlogin,
+#	Login-IP-Host = shellbox.ispdomain.com
+
+# #
+# # Last default: shell on the local terminal server.
+# #
+# DEFAULT
+# 	Service-Type = Administrative-User
+
+
+# On no match, the user is denied access.
+
+
+#########################################################
+# You should add test accounts to the TOP of this file! #
+# See the example user "bob" above.                     #
+#########################################################
+


### PR DESCRIPTION
Currently the FreeRADIUS parser does not work with newer configuration
files from freeRADIUS.
After updating the parser and rewriting some tests this should work for
now.

TODO: Some configuration elements are unsupported at the moment
(continuation, references)

Working on #2