### PR TITLE
Enable tests with tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
-[report]
+[run]
 omit =
+    setup.py
 
+[report]
 exclude_lines =
     pragma: no cover
-    except Exception

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/*
 __pycache__/*
 *.pyc
 htmlcov/*
+.tox/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ sudo: false
 python:
   - 2.7
   - 3.6
+
 # command to install dependencies
 install:
-  - "pip install ."
-  - "pip install pytest"
-  - "pip install pytest-cov"
+  - "pip install tox-travis"
   - "pip install coveralls"
+
 # command to run tests
-script: "python -b -m pytest --cov-report=html --cov=freeradiusparser"
+script: "tox"
 
 after_success:
     coveralls --rcfile=coveragerc

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 # FreeRADIUS clients.conf parser
 
-A python module to parse the clients.conf file
+A python module to parse the ``clients.conf`` and ``users`` file
 of FreeRADIUS.
 
 Clients can be read, edited, added and deleted.
 
 ## Tests
 
-Run coverage with:
+Run tests with:
 
-   py.test --cov-report=html --cov=freeradiusparser
+    tox

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(name='freeradiusparser',
-      version='0.1',
+      packages=find_packages(),
+      version='0.2',
       description='FreeRADIUS parser for clients.conf',
       author='Cornelius Kölbel',
       author_email='cornelius.koelbel@netknights.it',
       url='https://github.com/privacyidea/freeradiusparser',
       py_modules=['freeradiusparser'],
-      install_requires = [
-          'pyparsing>=2.0'
-      ]
-)
+      install_requires=[
+            'pyparsing>=2.0',
+            'six'
+      ],
+      )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27,py36
+
+[testenv]
+# install pytest in the virtualenv where commands will be executed
+deps =
+    pytest
+    pytest-cov
+commands =
+    # NOTE: you can run any command line tool here - not just tests
+    python -b -m pytest --cov=freeradiusparser


### PR DESCRIPTION
tox takes care of setting up several environments for tests and integrates
well with travis.
Update coverage configuration to exclude ``setup.py``